### PR TITLE
Use useLockedSky hook for voting weight calculation in the delegate page

### DIFF
--- a/modules/delegates/components/DelegateSKYDelegatedStats.tsx
+++ b/modules/delegates/components/DelegateSKYDelegatedStats.tsx
@@ -12,8 +12,8 @@ import { Delegate } from 'modules/delegates/types';
 import { StatBox } from 'modules/app/components/StatBox';
 import { useAccount } from 'modules/app/hooks/useAccount';
 import { formatValue } from 'lib/string';
-import { useSkyVotingWeight } from 'modules/sky/hooks/useSkyVotingWeight';
 import Skeleton from 'react-loading-skeleton';
+import { useLockedSky } from 'modules/sky/hooks/useLockedSky';
 
 export function DelegateSKYDelegatedStats({
   delegate,
@@ -27,9 +27,9 @@ export function DelegateSKYDelegatedStats({
 
   const { data: skyDelegatedData } = useSkyDelegatedByUser(account, delegate.voteDelegateAddress);
   const totalSkyDelegated = skyDelegatedData?.totalDelegationAmount;
-  const { data: votingWeight, loading: votingWeightLoading } = useSkyVotingWeight({
-    address: delegate.voteDelegateAddress
-  });
+  
+  const { data: totalLocked, loading: votingWeightLoading } = useLockedSky(delegate.voteDelegateAddress);
+  const votingWeight = totalLocked;
 
   return (
     <Flex


### PR DESCRIPTION
Previously, delegate balances were only updating immediately on the delegates list page after delegation. The delegate detail page and user account page (for delegate owners) required a page refresh to see updated balances.

This PR ensures that delegate balances update in real-time across all pages after delegation/undelegation actions.