### PR TITLE
fix: Clear poll transaction status when navigating to other pages

### DIFF
--- a/modules/polling/context/BallotContext.tsx
+++ b/modules/polling/context/BallotContext.tsx
@@ -446,6 +446,7 @@ export const BallotProvider = ({ children }: PropTypes): React.ReactElement => {
     setTxId(null);
     setStep('initial');
     setSubmissionMethod(null);
+    setSubmissionError(undefined);
   };
 
   useEffect(() => {

--- a/pages/polling/review.tsx
+++ b/pages/polling/review.tsx
@@ -54,7 +54,7 @@ const PollingReview = ({ polls: activePolls, activePollIds, tags }: PollingRevie
     setShowMarkdownModal(!showMarkdownModal);
   };
 
-  const { ballot, previousBallot, transaction, ballotCount } = useContext(BallotContext);
+  const { ballot, previousBallot, transaction, ballotCount, close } = useContext(BallotContext);
 
   const { account } = useAccount();
 
@@ -183,7 +183,7 @@ const PollingReview = ({ polls: activePolls, activePollIds, tags }: PollingRevie
             <Stack gap={3}>
               <Box>
                 <InternalLink href={'/polling'} title="View polling page">
-                  <Button variant="mutedOutline" sx={{ width: 'max-content' }}>
+                  <Button variant="mutedOutline" sx={{ width: 'max-content' }} onClick={close}>
                     <Icon name="chevron_left" size={2} sx={{ mr: 2 }} />
                     Back to All Polls
                   </Button>

--- a/pages/polling/review.tsx
+++ b/pages/polling/review.tsx
@@ -7,7 +7,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 */
 
 import { GetStaticProps } from 'next';
-import { useContext, useMemo, useState } from 'react';
+import { useContext, useMemo, useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
 import { Heading, Box, Button, Flex, Text } from 'theme-ui';
 import Icon from 'modules/app/components/Icon';
 import ErrorPage from 'modules/app/components/ErrorPage';
@@ -46,6 +47,7 @@ export type PollingReviewPageProps = {
 const PollingReview = ({ polls: activePolls, activePollIds, tags }: PollingReviewPageProps) => {
   const bpi = useBreakpointIndex();
   const network = useNetwork();
+  const router = useRouter();
 
   const [showMarkdownModal, setShowMarkdownModal] = useState(false);
   const [modalPollId, setModalPollId] = useState<number | undefined>(undefined);
@@ -57,6 +59,23 @@ const PollingReview = ({ polls: activePolls, activePollIds, tags }: PollingRevie
   const { ballot, previousBallot, transaction, ballotCount, close } = useContext(BallotContext);
 
   const { account } = useAccount();
+
+  // Clear transaction state when navigating away from the review page
+  useEffect(() => {
+    const handleRouteChange = (url: string) => {
+      // If navigating away from review page, clear transaction state
+      if (!url.includes('/polling/review')) {
+        close();
+      }
+    };
+
+    router.events.on('routeChangeStart', handleRouteChange);
+
+    // Cleanup
+    return () => {
+      router.events.off('routeChangeStart', handleRouteChange);
+    };
+  }, [router, close]);
 
   // Used to create a string that does not trigger the useMemo of votedPolls to be recreated. (Unique string does not re-render the votedPolls object)
   const ballotKeys = useMemo(() => {
@@ -183,7 +202,7 @@ const PollingReview = ({ polls: activePolls, activePollIds, tags }: PollingRevie
             <Stack gap={3}>
               <Box>
                 <InternalLink href={'/polling'} title="View polling page">
-                  <Button variant="mutedOutline" sx={{ width: 'max-content' }} onClick={close}>
+                  <Button variant="mutedOutline" sx={{ width: 'max-content' }}>
                     <Icon name="chevron_left" size={2} sx={{ mr: 2 }} />
                     Back to All Polls
                   </Button>


### PR DESCRIPTION
This PR fixes a critical UX issue where failed transaction states persist when users navigate away from the ballot review page. Previously, if a user rejected a transaction and then clicked "Back to all polls", the failed transaction would reappear when returning to the review page, blocking them from proceeding with their vote.

Test Plan

  - Submit a vote on the ballot page and reject the transaction
  - Click "Back to all polls"
  - Navigate back to the same poll and click "Review & Submit"
  - Verify that the failed transaction state is cleared and you can proceed with voting
  - Test navigation using browser back/forward buttons
  - Test direct URL navigation away from the review page