### PR TITLE
Fix missing endpoint doc

### DIFF
--- a/pages/api/executive/[proposal-id].ts
+++ b/pages/api/executive/[proposal-id].ts
@@ -117,6 +117,15 @@ import { ApiError } from 'modules/app/api/ApiError';
  *         hasBeenScheduled: true
  *         skySupport: "150000.75"
  *         eta: "2023-10-28T12:00:00Z"
+ *   NotFoundResponse:
+ *     type: object
+ *     properties:
+ *       message:
+ *         type: string
+ *         description: Error message explaining why the proposal was not found
+ *       code:
+ *         type: integer
+ *         description: HTTP status code (404)
  *
  * /api/executive/{proposal-id}:
  *   get:
@@ -154,16 +163,6 @@ import { ApiError } from 'modules/app/api/ApiError';
  *           application/json:
  *             schema:
  *               $ref: '#/definitions/NotFoundResponse'
- * definitions:
- *   NotFoundResponse:
- *     type: object
- *     properties:
- *       message:
- *         type: string
- *         description: Error message explaining why the proposal was not found
- *       code:
- *         type: integer
- *         description: HTTP status code (404)
  */
 export default withApiHandler(
   async (req: NextApiRequest, res: NextApiResponse<ExecutiveProposalType | NotFoundResponse>) => {


### PR DESCRIPTION
### What does this PR do?
Due to a duplicate definition, the swagger doc for the proposal id endpoint was not displaying on the API docs page

Before:
<img width="2816" height="588" alt="Screenshot 2025-07-15 at 11 02 19 AM" src="https://github.com/user-attachments/assets/92fa46f8-05b7-4a2c-a568-2c15200a875d" />

After:
<img width="2814" height="734" alt="Screenshot 2025-07-15 at 11 02 11 AM" src="https://github.com/user-attachments/assets/50a2bbe1-ac16-4516-955a-c846224d2335" />
