### PR TITLE
Only fetch user specific events in the useSkyDelegatedByUser hook

### DIFF
--- a/modules/delegates/api/fetchDelegationEventsByUser.ts
+++ b/modules/delegates/api/fetchDelegationEventsByUser.ts
@@ -1,0 +1,55 @@
+/*
+
+SPDX-FileCopyrightText: © 2023 Dai Foundation <www.daifoundation.org>
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+
+*/
+
+import logger from 'lib/logger';
+import { gqlRequest } from 'modules/gql/gqlRequest';
+import { userDelegationToDelegate } from 'modules/gql/queries/subgraph/userDelegationToDelegate';
+import { SupportedNetworks } from 'modules/web3/constants/networks';
+import { networkNameToChainId } from 'modules/web3/helpers/chain';
+import { SkyLockedDelegateApiResponse } from '../types';
+import { formatEther } from 'viem';
+
+export async function fetchDelegationEventsByUser(
+  delegateAddress: string,
+  userAddress: string,
+  network: SupportedNetworks
+): Promise<SkyLockedDelegateApiResponse[]> {
+  try {
+    const data = await gqlRequest({
+      chainId: networkNameToChainId(network),
+      query: userDelegationToDelegate,
+      variables: {
+        delegate: delegateAddress.toLowerCase(),
+        delegator: userAddress.toLowerCase()
+      }
+    });
+    
+    if (!data.delegate) {
+      return [];
+    }
+    
+    const delegationHistory = data.delegate.delegationHistory;
+
+    const addressData: SkyLockedDelegateApiResponse[] = delegationHistory.map(x => {
+      return {
+        delegateContractAddress: x.delegate.id,
+        immediateCaller: x.delegator,
+        lockAmount: formatEther(x.amount),
+        blockNumber: x.blockNumber,
+        blockTimestamp: new Date(parseInt(x.timestamp) * 1000).toISOString(),
+        hash: x.txnHash,
+        callerLockTotal: formatEther(x.accumulatedAmount),
+        isStakingEngine: x.isStakingEngine
+      };
+    });
+    return addressData;
+  } catch (e) {
+    logger.error('fetchDelegationEventsByUser: Error fetching delegation events', e.message);
+    return [];
+  }
+}

--- a/modules/gql/queries/subgraph/userDelegationToDelegate.ts
+++ b/modules/gql/queries/subgraph/userDelegationToDelegate.ts
@@ -1,0 +1,28 @@
+/*
+
+SPDX-FileCopyrightText: © 2023 Dai Foundation <www.daifoundation.org>
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+
+*/
+
+import { gql } from 'graphql-request';
+
+export const userDelegationToDelegate = gql`
+  query userDelegationToDelegate($delegate: String!, $delegator: String!) {
+    delegate(id: $delegate) {
+      delegationHistory(first: 1000, where: {delegator: $delegator}) {
+        amount
+        accumulatedAmount
+        delegator
+        blockNumber
+        timestamp
+        txnHash
+        delegate {
+          id
+        }
+        isStakingEngine
+      }
+    }
+  }
+`;

--- a/modules/sky/hooks/useSkyDelegatedByUser.ts
+++ b/modules/sky/hooks/useSkyDelegatedByUser.ts
@@ -9,7 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 import useSWR from 'swr';
 import { useChainId } from 'wagmi';
 import { chainIdToNetworkName } from 'modules/web3/helpers/chain';
-import { fetchDelegationEventsByAddresses } from 'modules/delegates/api/fetchDelegationEventsByAddresses';
+import { fetchDelegationEventsByUser } from 'modules/delegates/api/fetchDelegationEventsByUser';
 import { config } from 'lib/config';
 import { getPublicClient } from 'modules/web3/helpers/getPublicClient';
 import { voteDelegateAbi } from 'modules/contracts/ethers/abis';
@@ -70,8 +70,8 @@ export const useSkyDelegatedByUser = (
         return fetchFromChain(userAddress as string, voteDelegateAddress);
       }
       try {
-        const data = await fetchDelegationEventsByAddresses([voteDelegateAddress], network);
-        const delegations = data.filter(x => x.immediateCaller.toLowerCase() === userAddress?.toLowerCase());
+        const delegations = await fetchDelegationEventsByUser(voteDelegateAddress, userAddress!, network);
+        
         let stakingEngineDelegated = 0n;
         let directDelegated = 0n; // Calculate this as needed
         for (let i = 0; i < delegations.length; i++) {


### PR DESCRIPTION
  - Performance optimization: Replaces generic fetchDelegationEventsByAddresses with targeted
  fetchDelegationEventsByUser that queries delegation events for a specific user-delegate pair
  - New GraphQL query: Adds userDelegationToDelegate query that filters delegation history at the subgraph level
  rather than fetching all delegations and filtering client-side
  - Reduced data transfer: Only fetches delegation events where a specific user delegated to a specific delegate,
  significantly reducing the amount of data transferred from the subgraph
